### PR TITLE
Fixed `undefined` on Unicode-named media with long names

### DIFF
--- a/upcoming-media-card.js
+++ b/upcoming-media-card.js
@@ -269,6 +269,7 @@ class UpcomingMediaCard extends HTMLElement {
     this.content.innerHTML = "";
 
     // Truncate text...
+    const non_letter_pattern = new RegExp("( |:|-|;|\"|'|,)", "g");
     function truncate(text, chars) {
       // When to truncate depending on size
       chars = chars == "large" ? 23 : chars == "medium" ? 28 : 35;
@@ -278,11 +279,13 @@ class UpcomingMediaCard extends HTMLElement {
       if (text.length > chars) {
         for (let i = chars; i > 0; i--) {
           if (
-            text.charAt(i).match(/( |:|-|;|"|'|,)/) &&
-            text.charAt(i - 1).match(/[a-zA-Z0-9_]/)
+            text.charAt(i).match(non_letter_pattern) &&
+            !text.charAt(i - 1).match(non_letter_pattern)
           ) {
             return `${text.substring(0, i)}...`;
           }
+          // The cycle above had a really big single word, so we return it anyway
+          return text;
         }
       } else {
         return text;

--- a/upcoming-media-card.js
+++ b/upcoming-media-card.js
@@ -269,24 +269,20 @@ class UpcomingMediaCard extends HTMLElement {
     this.content.innerHTML = "";
 
     // Truncate text...
-    const non_letter_pattern = new RegExp("( |:|-|;|\"|'|,)", "g");
     function truncate(text, chars) {
       // When to truncate depending on size
-      chars = chars == "large" ? 23 : chars == "medium" ? 28 : 35;
+      chars = chars == 'large' ? 23 : chars == 'medium' ? 28 : 35;
       // Remove parentheses & contents: "Shameless (US)" becomes "Shameless".
-      text = text.replace(/ *\([^)]*\) */g, " ");
+      text = text.replace(/ *\([^)]*\) */g, ' ');
       // Truncate only at whole word w/ no punctuation or space before ellipsis.
       if (text.length > chars) {
         for (let i = chars; i > 0; i--) {
-          if (
-            text.charAt(i).match(non_letter_pattern) &&
-            !text.charAt(i - 1).match(non_letter_pattern)
-          ) {
+          if (text.charAt(i).match(/( |\s|:|-|;|"|'|,)/) && text.charAt(i - 1).match(/[a-zA-Z0-9_]/)) {
             return `${text.substring(0, i)}...`;
           }
-          // The cycle above had a really big single word, so we return it anyway
-          return text;
         }
+        // The cycle above had a really big single word, so we return it anyway
+        return `${text.substring(0, chars)}...`;
       } else {
         return text;
       }


### PR DESCRIPTION
I have movie titles translated in Russian, Korean, etc., and they show up as undefined, because that cycle never results in a return, and that letter matching never matches the letters. This should fix it.