### PR TITLE
Add support for music variables

### DIFF
--- a/upcoming-media-card.js
+++ b/upcoming-media-card.js
@@ -352,7 +352,7 @@ class UpcomingMediaCard extends HTMLElement {
       let char = [title_size, line1_size, line2_size, line3_size, line4_size];
 
       // Keyword map for replacement, return null if empty so we can hide empty sections
-      let keywords = /\$title|\$episode|\$genres|\$number|\$rating|\$release|\$runtime|\$studio|\$day|\$date|\$time|\$aired/g;
+      let keywords = /\$title|\$episode|\$genres|\$number|\$rating|\$release|\$runtime|\$studio|\$day|\$date|\$time|\$aired|\$album|\$artist/g;
       let keys = {
         $title: item("title") || null,
         $episode: item("episode") || null,
@@ -361,6 +361,8 @@ class UpcomingMediaCard extends HTMLElement {
         $rating: item("rating") || null,
         $release: item("release") || null,
         $studio: item("studio") || null,
+        $album: item("album") || null,
+        $artist: item("artist") || null,
         $runtime: runtime || null,
         $day: day || null,
         $time: airdate.toLocaleTimeString([], timeform) || null,


### PR DESCRIPTION
I've recently created two sensors that feed data into the upcoming media card. A Sonos one that feeds your upcoming queue and a lidarr one that displays upcoming album releases. In both cases I had to resort to populating variables that didn't really align with the data they held. This pull requests adds two variables (album and artist) to the base card to better support sensors that return music data. 

This is my first pull request and have marked it as a draft in case something hasn't been done correctly or if you can think of other music related variables to add.

Thanks for your consideration